### PR TITLE
Sub liquid back into HTMLCheck

### DIFF
--- a/lib/canvas/checks/valid_html_check.rb
+++ b/lib/canvas/checks/valid_html_check.rb
@@ -7,7 +7,7 @@ module Canvas
 
         next if validator.validate
 
-        validator.errors.map(&:message).each do |message|
+        validator.errors.each do |message|
           @offenses << Offense.new(
             message: "Invalid HTML: #{filename} - \n#{message}"
           )

--- a/spec/canvas/checks/valid_html_check_spec.rb
+++ b/spec/canvas/checks/valid_html_check_spec.rb
@@ -15,7 +15,7 @@ describe Canvas::ValidHtmlCheck do
       message = <<~MESSAGE.chop
         Invalid HTML: blocks/hero/block.liquid - \n
         14:16: ERROR: Start tag of nonvoid HTML element ends with '/>', use '>'.
-        <h1>           <foo/>
+        <h1>{{heading}}<foo/>
                        ^
       MESSAGE
 


### PR DESCRIPTION
We have to remove liquid tags from the document for us to be able to run
the Nokogiri parsing on it, originally we did this by subbing in spaces
in the place of liquid tags, this led to some odd error messages with
big gaps where there would've been liquid tags.

Here we move to an approach similar to that used by Shopify in their
theme check tool to replace the tag with a keyed placeholder and then
sub those back in based on the key when we present the error back to the
user.