### PR TITLE
Resolve gem warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    easol-canvas (0.1.1)
+    easol-canvas (1.0.0)
       cli-ui (~> 1.5)
       liquid (~> 5.3)
       nokogiri (~> 1.13)

--- a/canvas.gemspec
+++ b/canvas.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "easol-canvas"
-  s.version     = "0.1.1"
+  s.version     = "1.0.0"
   s.summary     = "CLI to help with building themes for Easol"
   s.description = <<~EOF
     Canvas is a command line tool to help with building themes for Easol.

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,3 +1,3 @@
 module Canvas
-  VERSION = "0.1.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
This PR fixes some warnings that were being shown when running `gem build`. It also bumps the version to v1.0.0.