### PR TITLE
Ensure custom type key is not reserved word

### DIFF
--- a/lib/canvas/validators/custom_type.rb
+++ b/lib/canvas/validators/custom_type.rb
@@ -38,6 +38,7 @@ module Canvas
           ensure_has_required_keys &&
           ensure_no_unrecognized_keys &&
           ensure_keys_are_correct_types &&
+          ensure_key_value_is_not_reserved &&
           ensure_no_duplicate_attributes &&
           ensure_attributes_are_valid &&
           ensure_first_attribute_not_array
@@ -85,6 +86,17 @@ module Canvas
             schema["attributes"].empty? ||
             schema["attributes"].any? { |a| !a.is_a?(Hash) }
             @errors << "\"attributes\" must be an array of objects"
+          return false
+        end
+
+        true
+      end
+
+      # Ensuring the value for key doesn't clash with our primitive type keys.
+      # See {Canvas::Constants::PRIMITIVE_TYPES}
+      def ensure_key_value_is_not_reserved
+        if schema["key"] && Constants::PRIMITIVE_TYPES.include?(schema["key"].downcase)
+          @errors << "\"key\" can't be one of these reserved words: #{Constants::PRIMITIVE_TYPES.join(', ')}"
           return false
         end
 

--- a/spec/lib/canvas/validators/custom_type_spec.rb
+++ b/spec/lib/canvas/validators/custom_type_spec.rb
@@ -109,6 +109,26 @@ describe Canvas::Validator::CustomType do
       end
     end
 
+    context "when key is a reserved word" do
+      let(:schema) {
+        {
+          "key" => "string",
+          "name" => "Card",
+          "attributes" => [
+            {
+              "name" => "title",
+              "type" => "string"
+            }
+          ]
+        }
+      }
+
+      it "returns false with errors" do
+        expect(validator.validate).to eq(false)
+        expect(validator.errors).to include("\"key\" can't be one of these reserved words: #{Canvas::Constants::PRIMITIVE_TYPES.join(', ')}")
+      end
+    end
+
     context "when schema has empty attributes" do
       let(:schema) {
         {


### PR DESCRIPTION
In the Rails app, we currently validate that custom type `key` is not a reserved word, i.e. it is not one of the primitive types. This validation can be seen in [Site::VariableType](https://github.com/easolhq/easol/blob/main/app/models/site/variable_type.rb#L95-L101).

We want to move this validation out of Rails and into the canvas gem.