### PR TITLE
Schemas Block Checker - invalid YAML

### DIFF
--- a/spec/examples/alchemist/blocks/index.json
+++ b/spec/examples/alchemist/blocks/index.json
@@ -14,5 +14,9 @@
   "heading": {
     "name": "Heading",
     "category": "Text"
+  },
+  "invalid_yaml": {
+    "name": "Invalid YAML",
+    "category": "Text"
   }
 }

--- a/spec/examples/alchemist/blocks/invalid_yaml/block.liquid
+++ b/spec/examples/alchemist/blocks/invalid_yaml/block.liquid
@@ -1,0 +1,7 @@
+---
+attributes
+  image:
+  type: image
+---
+
+<img src="{{ image.url }}" alt="{{ image.alt }}" />

--- a/spec/lib/canvas/checks/valid_block_schemas_check_spec.rb
+++ b/spec/lib/canvas/checks/valid_block_schemas_check_spec.rb
@@ -41,6 +41,12 @@ describe Canvas::ValidBlockSchemasCheck do
               Invalid Block Schema: blocks/text_with_layout/block.liquid - \n
               Unrecognized attribute `unknown`. Location: layout/0/elements/2
             MESSAGE
+          ),
+          have_attributes(
+            message: <<~MESSAGE.chop.squeeze("\n")
+              Invalid Block Schema: blocks/invalid_yaml/block.liquid - \n
+              Front matter's YAML is not in a valid format
+            MESSAGE
           )
         ]
       )


### PR DESCRIPTION
When loading / parsing front matter's YAML, we should rescue
Psych::SyntaxError and add offense about invalid YAML syntax.