### PR TITLE
Bump version to v2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    easol-canvas (1.5.0)
+    easol-canvas (2.0.0)
       cli-ui (~> 1.5)
       json-schema (~> 3)
       liquid (~> 5.3)
@@ -23,7 +23,7 @@ GEM
       addressable (>= 2.8)
     liquid (5.3.0)
     method_source (1.0.0)
-    nokogiri (1.13.7-arm64-darwin)
+    nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
     parallel (1.21.0)
     parser (3.0.3.2)

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "1.5.0"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
This version allows menu and footer schemas to also
have a `layout` key, in the same way as blocks.

Bumping the major version here because now the MenuSchema and
FooterSchema validators expect the `attributes` in the schema to be
in a hash format, where previously they expected an array format.

This change is not backwards compatible.