### PR TITLE
The currency_switcher tag is considered valid liquid

### DIFF
--- a/lib/canvas/checks/valid_liquid_check.rb
+++ b/lib/canvas/checks/valid_liquid_check.rb
@@ -38,6 +38,7 @@ module Canvas
       register_tag("easol_badge", ::Liquid::Tag)
       register_tag("accommodation_availability", ::Liquid::Block)
       register_tag("cache", ::Liquid::Block)
+      register_tag("currency_switcher", ::Liquid::Tag)
     end
   end
 end

--- a/spec/examples/vagabond/partials/footer/index.liquid
+++ b/spec/examples/vagabond/partials/footer/index.liquid
@@ -10,4 +10,8 @@ attributes:
     label: "My description"
 ---
 
-<footer>Thanks for looking at my site</footer>
+<footer>
+Thanks for looking at my site
+{% easol_badge %}
+{% currency_switcher %}
+</footer>


### PR DESCRIPTION
Assuming we have the all clear to use currency switcher! 

I added it as part of a bigger refactor of the vagabond footer but this linter was failing.
Is adding to the footer example acceptable approach for testing?