### PR TITLE
Remove "extras" from product attribute restrictions

### DIFF
--- a/lib/canvas/validators/schema_attributes/product.rb
+++ b/lib/canvas/validators/schema_attributes/product.rb
@@ -7,7 +7,7 @@ module Canvas
       # Attribute validations specific to product-type variables.
       class Product < Base
         ALLOWED_DEFAULT_VALUES = %w[random].freeze
-        ALLOWED_RESTRICTIONS = %w[experiences accommodations extras].freeze
+        ALLOWED_RESTRICTIONS = %w[experiences accommodations].freeze
 
         def validate
           super &&

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "3.3.0"
+  VERSION = "3.3.1"
 end

--- a/spec/lib/canvas/validators/schema_attributes/product_spec.rb
+++ b/spec/lib/canvas/validators/schema_attributes/product_spec.rb
@@ -26,7 +26,7 @@ describe Canvas::Validator::SchemaAttribute::Product do
 
       context "when `only` is provided" do
         it "is valid when using an array" do
-          all_allowed_values = %w[experiences accommodations extras]
+          all_allowed_values = %w[experiences accommodations]
           validator = described_class.new({
             "name" => "my_product",
             "type" => "product",
@@ -52,7 +52,7 @@ describe Canvas::Validator::SchemaAttribute::Product do
             "only" => ["unsupported"],
           })
           expect(validator.validate).to eq(false)
-          expect(validator.errors).to include(%["only" for product-type variables must be one of: experiences, accommodations, extras])
+          expect(validator.errors).to include(%["only" for product-type variables must be one of: experiences, accommodations])
         end
 
         it "is invalid when not an array" do


### PR DESCRIPTION
It is not an option we can support in this context.

This should be a major version change, but no one is using the new `only` key yet, so it feels OK to add it as a fix (patch version bump).

Related to #43.