### PR TITLE
Add package type and validator

### DIFF
--- a/lib/canvas/constants.rb
+++ b/lib/canvas/constants.rb
@@ -26,6 +26,7 @@ module Canvas
       string
       text
       variant
+      package
     ].freeze
 
     # These are types where the value is stored as a primitive type, e.g. string, integer.

--- a/lib/canvas/validators/schema_attribute.rb
+++ b/lib/canvas/validators/schema_attribute.rb
@@ -33,6 +33,7 @@ module Canvas
         "range" => SchemaAttribute::Range,
         "radio" => SchemaAttribute::Radio,
         "variant" => SchemaAttribute::Variant,
+        "package" => SchemaAttribute::Package,
       }.freeze
       RESERVED_NAMES = %w[
         page

--- a/lib/canvas/validators/schema_attributes/package.rb
+++ b/lib/canvas/validators/schema_attributes/package.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Canvas
+  module Validator
+    class SchemaAttribute
+      # :documented:
+      # Attribute validations specific to package-type variables.
+      class Package < Base
+        ALLOWED_DEFAULT_VALUES = %w[random].freeze
+
+        def validate
+          super &&
+            ensure_default_values_are_valid
+        end
+
+        private
+
+        def permitted_values_for_default_key
+          if attribute["array"]
+            Array
+          else
+            String
+          end
+        end
+
+        def ensure_default_values_are_valid
+          return true unless attribute.key?("default")
+
+          if attribute["array"]
+            attribute["default"].all? { |value| default_value_is_valid?(value) }
+          else
+            default_value_is_valid?(attribute["default"])
+          end
+        end
+
+        def default_value_is_valid?(value)
+          value = value.downcase
+          if !ALLOWED_DEFAULT_VALUES.include?(value)
+            @errors << "\"default\" for package-type variables must be "\
+                       "one of: #{ALLOWED_DEFAULT_VALUES.join(', ')}"
+            false
+          else
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/canvas/validators/menu_schema_spec.rb
+++ b/spec/lib/canvas/validators/menu_schema_spec.rb
@@ -153,7 +153,7 @@ describe Canvas::Validator::MenuSchema do
           expect(validator.errors).to include(
             "Attribute \"images\" is invalid - \"type\" must be one of: " \
             "boolean, color, image, link, number, page, post, product, " \
-            "radio, range, select, string, text, variant"
+            "radio, range, select, string, text, variant, package"
           )
         end
       end

--- a/spec/lib/canvas/validators/schema_attributes/package_spec.rb
+++ b/spec/lib/canvas/validators/schema_attributes/package_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+describe Canvas::Validator::SchemaAttribute::Package do
+  subject(:validator) {
+    Canvas::Validator::SchemaAttribute::Package.new(attribute)
+  }
+
+  describe "#validate" do
+    describe "validating an optional 'default' key" do
+      let(:attribute) {
+        {
+          "name" => "my_package",
+          "type" => "package",
+          "default" => default_value
+        }
+      }
+
+      context "when unknown default value is provided" do
+        let(:default_value) { "FAIL" }
+
+        it "adds an error and fails the validation" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include(
+            "\"default\" for package-type variables must be one of: random"
+          )
+        end
+      end
+
+      context "when `random` default value is provided" do
+        let(:default_value) { "Random" }
+
+        it "passes the validation" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+
+      context "when `default` is an array of invalid options" do
+        let(:attribute) {
+          {
+            "name" => "my_package",
+            "type" => "package",
+            "array" => true,
+            "default" => %w[random modnar]
+          }
+        }
+        it "returns false" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include(
+            "\"default\" for package-type variables must be one of: random"
+          )
+        end
+      end
+
+      context "when `default` is an array of valid options" do
+        let(:attribute) {
+          {
+            "name" => "my_package",
+            "type" => "package",
+            "array" => true,
+            "default" => %w[Random random]
+          }
+        }
+        it "returns true" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a simple package type and validator, we noticed that the validator has the identical shape to a lot of others, but feels out of scope to extract this here?

Ticket: https://trello.com/c/0U3XGYvM/360-displaying-packages-within-sites