### PR TITLE
Introduce Github Action for release phase

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: release
+run-name: Publish and release new version
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup git user
+        run: |
+          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+
+      - run: bundle install
+      - run: bundle exec rspec
+      - run: bundle exec rubocop
+
+      - name: Build and publish gem
+        run: bundle exec rake release[remote]
+        env:
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - "bin/*"
     - "spec/examples/*"
     - "spec/spec_helper.rb"
+    - "vendor/**/*"
 
 Bundler/DuplicatedGem:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 gemspec
 
 group :development, :test do
+  gem "gem-release"
   gem "pry"
   gem "rspec"
   gem "rubocop", require: false

--- a/README.md
+++ b/README.md
@@ -128,13 +128,15 @@ cd alchemist_theme
 
 1. Implement your code changes.
 2. Bump the version in the code:
-    1. Update the version in `lib/canvas/version.rb`.
-    2. Commit these changes.
+   1. bundle exec gem bump --version [minor|major|patch]
+   2. Commit these changes.
 3. Push changes, wait for PR to be approved, then merge to `main`.
-4. Pull the latest from `main` and then run the following rake task locally:
-
-    ```
-    rake release[origin]
-    ```
-    This will tag the gem, push the tag to github, build the gem, and push it to [rubygems.org](http://rubygems.org). You will need to have a RubyGem account and be added to the project.
-5. On major version changes, update the version lock in the [canvas-linter-action](https://github.com/easolhq/canvas-linter-action/blob/main/entrypoint.sh) repo.
+4. Pull the latest from `main` and then tag the latest version via git:
+   ```
+   bundle exec gem tag
+   ```
+5. Push created tag which will trigger Github actions responsible for publishing
+   new version of the gem to rubygems.org repository
+6. On major version changes, update the version lock in the
+   [canvas-linter-action](https://github.com/easolhq/canvas-linter-action/blob/main/entrypoint.sh)
+   repo.


### PR DESCRIPTION
Github Action will be trigger when user create Github release. It will run all checks on gem like tests and linter.

At the end it will publish gem to Rubygems repository.

It also includes updated README file with detail instruction.

### Steps:
1. Bump version by using:
```
bundle exec gem bump --version [minor|major|patch]
```

2. Create new tag for newest version
```
bundle exec gem tag
```
3. Create Github release which will trigger Github Actions
