### PR TITLE
Add max_item_levels as optional block variable key

### DIFF
--- a/lib/canvas/validators/schema_attributes/base.rb
+++ b/lib/canvas/validators/schema_attributes/base.rb
@@ -53,6 +53,7 @@ module Canvas
           {
             "default" => permitted_values_for_default_key,
             "array" => [true, false],
+            "max_item_levels" => [1, 2, 3],
             "label" => String,
             "hint" => String,
             "group" => %w[content layout design mobile]

--- a/spec/lib/canvas/validators/schema_attributes/base_spec.rb
+++ b/spec/lib/canvas/validators/schema_attributes/base_spec.rb
@@ -15,7 +15,8 @@ describe Canvas::Validator::SchemaAttribute::Base do
           "label" => "My Title",
           "hint" => "This field is important",
           "group" => "content",
-          "array" => true
+          "array" => true,
+          "max_item_levels" => 3
         }
       }
 
@@ -106,6 +107,24 @@ describe Canvas::Validator::SchemaAttribute::Base do
         expect(validator.validate).to eq(false)
         expect(validator.errors).to include(
           "\"array\" is 'a string value', expected one of: true, false"
+        )
+      end
+    end
+
+    context "when max_item_levels is not 1, 2, or 3" do
+      let(:attribute) {
+        {
+          "name" => "my_title",
+          "type" => "text",
+          "array" => true,
+          "max_item_levels" => 4
+        }
+      }
+
+      it "returns false with errors" do
+        expect(validator.validate).to eq(false)
+        expect(validator.errors).to include(
+          "\"max_item_levels\" is '4', expected one of: 1, 2, 3"
         )
       end
     end


### PR DESCRIPTION
Problem: 
Theme developers can set up nested arrays as block variables. In `app/views/company/sites/form_builder/_array_input.html.erb` we currently sets `max_nesting_level` to a default of 1 for all array rows, so Creators cannot rearrange the nested items, they can only rearrange the top level items. 

By providing theme developers with an additional `max_item_levels` key, they can define the nesting level of each array, which we will shortly use in the `_array_input` partial. This will allow/prevent nesting on each level as necessary. We are naming this key `max_item_levels` to match the name of the key with similar behaviour used in the header and footer templates.

`max_item_levels` is to be used in conjunction with `array: true` to support nested arrays in block schema.

In an ideal world only one key would be needed to define this array behaviour. E.g. `array: true` resolves to a max_items_level of 1, and `array: false` continues to not render arrays. But a separate key seems the most easily backwards compatible. Thoughts here welcome.

Arbitrarily chosen to allow up to 3 levels of nesting. 