### PR TITLE
Support `json` tag

### DIFF
--- a/lib/canvas/checks/valid_liquid_check.rb
+++ b/lib/canvas/checks/valid_liquid_check.rb
@@ -39,6 +39,7 @@ module Canvas
       register_tag("accommodation_availability", ::Liquid::Block)
       register_tag("cache", ::Liquid::Block)
       register_tag("currency_switcher", ::Liquid::Tag)
+      register_tag("json", ::Liquid::Block)
     end
   end
 end


### PR DESCRIPTION
The `json` tag subclasses the `capture` tag and allows users to capture JSON directly into an object usable in Liquid.