### PR TITLE
Register experience date tag

### DIFF
--- a/lib/canvas/checks/valid_liquid_check.rb
+++ b/lib/canvas/checks/valid_liquid_check.rb
@@ -41,6 +41,7 @@ module Canvas
       register_tag("currency_switcher", ::Liquid::Tag)
       register_tag("json", ::Liquid::Block)
       register_tag("variant_pricing", ::Liquid::Tag)
+      register_tag("experience_date_search", ::Liquid::Block)
     end
   end
 end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.3.0"
+  VERSION = "4.4.0"
 end


### PR DESCRIPTION
This PR registers the new `experience_date_tag` so that the Canvas linter is aware of it as it's currently failing the build when the new tag is used

| Feature  | Before | After |
| ------------- | ------------- | ------------- |
| Running in Alchemist | ![image](https://github.com/easolhq/easol-canvas/assets/10531930/60c7f342-6bb2-426c-8fde-892ba7a6fa10) | <img width="754" alt="Screenshot 2023-08-15 at 17 15 09" src="https://github.com/easolhq/easol-canvas/assets/10531930/0d321f8c-0a29-4a37-8e84-22e3f0f43217"> |
