### PR TITLE
Rename ExperienceDateSearch to ExperienceSlotSearch

### DIFF
--- a/lib/canvas/checks/valid_liquid_check.rb
+++ b/lib/canvas/checks/valid_liquid_check.rb
@@ -41,7 +41,7 @@ module Canvas
       register_tag("currency_switcher", ::Liquid::Tag)
       register_tag("json", ::Liquid::Block)
       register_tag("variant_pricing", ::Liquid::Tag)
-      register_tag("experience_date_search", ::Liquid::Block)
+      register_tag("experience_slot_search", ::Liquid::Block)
     end
   end
 end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.4.0"
+  VERSION = "4.4.1"
 end


### PR DESCRIPTION
See easol[#PR10710](https://github.com/easolhq/easol/pull/10710)

We are updating the naming of experience 'dates' to experience 'slots' to future-proof for the slots being aware of time in addition to date.