### PR TITLE
Support `dartsass-rails` v0.5.0

### DIFF
--- a/canvas.gemspec
+++ b/canvas.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency "nokogiri", "~> 1.13"
   s.add_dependency "cli-ui", "~> 1.5"
   s.add_dependency "liquid", "~> 5.3"
-  s.add_dependency "dartsass-rails", ">= 0.4.0", "< 0.6.0"
+  s.add_dependency "dartsass-rails", "~> 0.4"
   s.add_dependency "json-schema", "~> 3"
 end

--- a/canvas.gemspec
+++ b/canvas.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency "nokogiri", "~> 1.13"
   s.add_dependency "cli-ui", "~> 1.5"
   s.add_dependency "liquid", "~> 5.3"
-  s.add_dependency "dartsass-rails", "~> 0.4.0"
+  s.add_dependency "dartsass-rails", ">= 0.4.0", "< 0.6.0"
   s.add_dependency "json-schema", "~> 3"
 end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.4.1"
+  VERSION = "4.4.2"
 end


### PR DESCRIPTION
💁 Version 0.5.0 of `dartsass-rails` was [released on 18 June 2023](https://github.com/rails/dartsass-rails/releases/tag/v0.5.0). This change enables that version to be installed safely.