### PR TITLE
Slug 179 add experience date block variable

### DIFF
--- a/lib/canvas/constants.rb
+++ b/lib/canvas/constants.rb
@@ -28,6 +28,7 @@ module Canvas
       variant
       package
       date
+      experience_date
     ].freeze
 
     # These are types where the value is stored as a primitive type, e.g. string, integer.

--- a/lib/canvas/validators/schema_attribute.rb
+++ b/lib/canvas/validators/schema_attribute.rb
@@ -35,6 +35,7 @@ module Canvas
         "variant" => SchemaAttribute::Variant,
         "package" => SchemaAttribute::Package,
         "date" => SchemaAttribute::Date,
+        "experience_date" => SchemaAttribute::ExperienceDate,
       }.freeze
       RESERVED_NAMES = %w[
         page

--- a/lib/canvas/validators/schema_attributes/experience_date.rb
+++ b/lib/canvas/validators/schema_attributes/experience_date.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Canvas
+  module Validator
+    class SchemaAttribute
+      # :documented:
+      # Attribute validations specific to the experience_date variables.
+      class ExperienceDate < Base
+        ALLOWED_DEFAULT_VALUES = %w[next_upcoming].freeze
+
+        def validate
+          super && ensure_default_values_are_valid
+        end
+
+        private
+
+        def permitted_values_for_default_key
+          if attribute["array"]
+            Array
+          else
+            String
+          end
+        end
+
+        def ensure_default_values_are_valid
+          return true unless attribute.key?("default")
+
+          if attribute["array"]
+            attribute["default"].all? { |value| default_value_is_valid?(value) }
+          else
+            default_value_is_valid?(attribute["default"])
+          end
+        end
+
+        def default_value_is_valid?(value)
+          value = value.downcase
+          if !ALLOWED_DEFAULT_VALUES.include?(value)
+            @errors << %["default" for experience_date variables must be one of: #{ALLOWED_DEFAULT_VALUES.join(', ')}]
+            false
+          else
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.4.2"
+  VERSION = "4.5.0"
 end

--- a/spec/lib/canvas/validators/menu_schema_spec.rb
+++ b/spec/lib/canvas/validators/menu_schema_spec.rb
@@ -150,11 +150,11 @@ describe Canvas::Validator::MenuSchema do
 
         it "returns false with errors" do
           expect(validator.validate).to eq(false)
-          expect(validator.errors).to include(
-            "Attribute \"images\" is invalid - \"type\" must be one of: " \
-            "boolean, color, image, link, number, page, post, product, " \
-            "radio, range, select, string, text, variant, package, date"
-          )
+          expect(validator.errors)
+            .to include(
+              "Attribute \"images\" is invalid - \"type\" must be one of: " +
+                Canvas::Constants::PRIMITIVE_TYPES.join(", ")
+            )
         end
       end
 

--- a/spec/lib/canvas/validators/schema_attributes/experience_date_spec.rb
+++ b/spec/lib/canvas/validators/schema_attributes/experience_date_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+describe Canvas::Validator::SchemaAttribute::ExperienceDate do
+  subject(:validator) { described_class.new(attribute) }
+
+  describe "#validate" do
+    describe "validating an optional 'default' key" do
+      let(:attribute) {
+        {
+          "name" => "my_date",
+          "type" => "experience_date",
+          "default" => default_value
+        }
+      }
+
+      context "when unknown default value is provided" do
+        let(:default_value) { "FAIL" }
+
+        it "adds an error and fails the validation" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include(
+            "\"default\" for experience_date variables must be one of: next_upcoming"
+          )
+        end
+      end
+
+      context "when `next_upcoming` default value is provided" do
+        let(:default_value) { "Next_upcoming" }
+
+        it "passes the validation" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+
+      context "when `default` is an array of invalid options" do
+        let(:attribute) {
+          {
+            "name" => "my_date",
+            "type" => "experience_date",
+            "array" => true,
+            "default" => %w[next_upcoming unknown]
+          }
+        }
+        it "returns false" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include(
+            "\"default\" for experience_date variables must be one of: next_upcoming"
+          )
+        end
+      end
+
+      context "when `default` is an array of valid options" do
+        let(:attribute) {
+          {
+            "name" => "my_variant",
+            "type" => "variant",
+            "array" => true,
+            "default" => %w[Next_upcoming next_upcoming]
+          }
+        }
+        it "returns true" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR makes it possible to use a new `experience_date` variable type in schemas. The plan is for this variable to return a `ExperienceSlotCalendar::DateDrop` object. 

The `next_upcoming` default value will allow fetching the next available date considering all the company's published experiences.

```
---
attributes:
  my_date:
    type: experience_date
    default: next_upcoming
---
```