### PR TITLE
SUN 34 Add ExperienceSlot block variable

### DIFF
--- a/lib/canvas/constants.rb
+++ b/lib/canvas/constants.rb
@@ -29,6 +29,7 @@ module Canvas
       package
       date
       experience_date
+      experience_slot
     ].freeze
 
     # These are types where the value is stored as a primitive type, e.g. string, integer.

--- a/lib/canvas/validators/schema_attribute.rb
+++ b/lib/canvas/validators/schema_attribute.rb
@@ -36,6 +36,7 @@ module Canvas
         "package" => SchemaAttribute::Package,
         "date" => SchemaAttribute::Date,
         "experience_date" => SchemaAttribute::ExperienceDate,
+        "experience_slot" => SchemaAttribute::ExperienceSlot,
       }.freeze
       RESERVED_NAMES = %w[
         page

--- a/lib/canvas/validators/schema_attributes/experience_slot.rb
+++ b/lib/canvas/validators/schema_attributes/experience_slot.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Canvas
+  module Validator
+    class SchemaAttribute
+      # :documented:
+      # Attribute validations specific to the experience_slot variables.
+      class ExperienceSlot < Base
+        ALLOWED_DEFAULT_VALUES = %w[next_upcoming].freeze
+
+        def validate
+          super && ensure_default_values_are_valid
+        end
+
+        private
+
+        def permitted_values_for_default_key
+          if attribute["array"]
+            Array
+          else
+            String
+          end
+        end
+
+        def ensure_default_values_are_valid
+          return true unless attribute.key?("default")
+
+          if attribute["array"]
+            attribute["default"].all? { |value| default_value_is_valid?(value) }
+          else
+            default_value_is_valid?(attribute["default"])
+          end
+        end
+
+        def default_value_is_valid?(value)
+          value = value.downcase
+          if !ALLOWED_DEFAULT_VALUES.include?(value)
+            @errors << %["default" for experience_slot variables must be one of: #{ALLOWED_DEFAULT_VALUES.join(', ')}]
+            false
+          else
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.5.0"
+  VERSION = "4.6.0"
 end

--- a/spec/lib/canvas/validators/schema_attributes/experience_slot_spec.rb
+++ b/spec/lib/canvas/validators/schema_attributes/experience_slot_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-describe Canvas::Validator::SchemaAttribute::ExperienceDate do
+describe Canvas::Validator::SchemaAttribute::ExperienceSlot do
   subject(:validator) { described_class.new(attribute) }
 
   describe "#validate" do
     describe "validating an optional 'default' key" do
       let(:attribute) {
         {
-          "name" => "my_date",
-          "type" => "experience_date",
+          "name" => "my_slot",
+          "type" => "experience_slot",
           "default" => default_value
         }
       }
@@ -19,7 +19,7 @@ describe Canvas::Validator::SchemaAttribute::ExperienceDate do
         it "adds an error and fails the validation" do
           expect(validator.validate).to eq(false)
           expect(validator.errors).to include(
-            "\"default\" for experience_date variables must be one of: next_upcoming"
+            "\"default\" for experience_slot variables must be one of: next_upcoming"
           )
         end
       end
@@ -35,8 +35,8 @@ describe Canvas::Validator::SchemaAttribute::ExperienceDate do
       context "when `default` is an array with an invalid option" do
         let(:attribute) {
           {
-            "name" => "my_date",
-            "type" => "experience_date",
+            "name" => "my_slot",
+            "type" => "experience_slot",
             "array" => true,
             "default" => %w[next_upcoming unknown]
           }
@@ -44,7 +44,7 @@ describe Canvas::Validator::SchemaAttribute::ExperienceDate do
         it "returns false" do
           expect(validator.validate).to eq(false)
           expect(validator.errors).to include(
-            "\"default\" for experience_date variables must be one of: next_upcoming"
+            "\"default\" for experience_slot variables must be one of: next_upcoming"
           )
         end
       end


### PR DESCRIPTION
I've simply followed Ian's approach when he [added the experience_date variable](https://github.com/easolhq/easol-canvas/pull/62).

This PR makes it possible to use a new experience_slot variable type in schemas. The plan is for this variable to return a ExperienceSlotDrop object.

The next_upcoming default value will allow fetching the next available slot considering all the company's published experiences.

```
---
attributes:
  my_slot:
    type: experience_slot
    default: next_upcoming
---
```

In an ideal world we would also let the creator select an experience, and default to the next available scoped to that experience, but we will cross that bridge when we come to it.

### Testing

If you update e.g. alchemist theme, so a block contains a variable with `type: experience_slot`
Running `canvas lint` you see this is invalid with the current version of this gem
Running `../canvas/bin/canvas lint` you see it is valid with these changes:

<img width="1502" alt="Screenshot 2023-12-12 at 12 45 22" src="https://github.com/easolhq/easol-canvas/assets/78875971/c266279e-c4d6-4a73-a8ed-8df177df832a">
