### PR TITLE
Add `experience_slot_calendar` to Canvas linter

### DIFF
--- a/lib/canvas/checks/valid_liquid_check.rb
+++ b/lib/canvas/checks/valid_liquid_check.rb
@@ -42,6 +42,7 @@ module Canvas
       register_tag("json", ::Liquid::Block)
       register_tag("variant_pricing", ::Liquid::Tag)
       register_tag("experience_slot_search", ::Liquid::Block)
+      register_tag("experience_slot_calendar", ::Liquid::Block)
     end
   end
 end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.6.1"
+  VERSION = "4.7.0"
 end


### PR DESCRIPTION
We have released the `experience_slot_calendar` but hadn't updated the
`register_tags` method for the linter. This meant that the linter has
been failing for the frontend team when working on themes. This resolves
that.