### PR TITLE
Update easol canvas gem to support enquiry form custom type

### DIFF
--- a/lib/canvas/validators/schema_attribute.rb
+++ b/lib/canvas/validators/schema_attribute.rb
@@ -37,6 +37,7 @@ module Canvas
         "date" => SchemaAttribute::Date,
         "experience_date" => SchemaAttribute::ExperienceDate,
         "experience_slot" => SchemaAttribute::ExperienceSlot,
+        "enquiry_form" => SchemaAttribute::Base,
       }.freeze
       RESERVED_NAMES = %w[
         page

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.7.0"
+  VERSION = "4.8.0"
 end


### PR DESCRIPTION
For now this uses the Base validator but we may want to extend later when we add support for things like default values to the enquiry form type.