### PR TITLE
[MICE-367] Register package availability tag

### DIFF
--- a/lib/canvas/checks/valid_liquid_check.rb
+++ b/lib/canvas/checks/valid_liquid_check.rb
@@ -43,6 +43,7 @@ module Canvas
       register_tag("variant_pricing", ::Liquid::Tag)
       register_tag("experience_slot_search", ::Liquid::Block)
       register_tag("experience_slot_calendar", ::Liquid::Block)
+      register_tag("package_availability", Liquid::Block)
       register_tag("input", ::Liquid::Tag)
       register_tag("label", ::Liquid::Tag)
     end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.8.2"
+  VERSION = "4.9.0"
 end


### PR DESCRIPTION
This PR registers the new `package_availability` tag so that the Canvas linter knows when it will start being used.