### PR TITLE
rf: allow accordion toggles to be nested under accordions

### DIFF
--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.9.0"
+  VERSION = "4.10.0"
 end

--- a/schema_definitions/layout.json
+++ b/schema_definitions/layout.json
@@ -46,7 +46,11 @@
         "elements": {
           "type": "array",
           "items": {
-            "oneOf": [{ "type": "string" }, { "$ref": "#/$defs/attribute" }]
+            "oneOf": [
+              { "type": "string" },
+              { "$ref": "#/$defs/accordion_toggle" },
+              { "$ref": "#/$defs/attribute" }
+            ]
           }
         }
       }

--- a/spec/examples/alchemist/blocks/text_with_layout/block.liquid
+++ b/spec/examples/alchemist/blocks/text_with_layout/block.liquid
@@ -11,6 +11,12 @@ attributes:
   image:
     label: "My image"
     type: image
+  color:
+    type: boolean
+    label: Update colours
+  card_background_color:
+    type: color
+    label: Card background colour
 layout:
   - label: "Content"
     type: tab
@@ -19,6 +25,13 @@ layout:
         type: attribute
       - subheading
       - unknown
+      - type: accordion
+        label: Booking card styles
+        elements:
+          - type: accordion_toggle
+            toggle_attribute: color
+            elements:
+              - card_background_color
 ---
 
 <h1>{{ heading }}</h1>


### PR DESCRIPTION
**Summary of the problem**
Currently, accordion elements only allow `attributes` to be nested within the accordion. This does not provide enough flexibility to accommodate the numerous options now available within each block.

**Summary of the changes**
This PR updates the canvas to also allow `accordion_toggle` elements to be nested within a parent `accordion` element. This allows us to conditionally display different variables to creators and hide those that aren't relevant to them.

This is a minor change and is backward compatible. The PR to introduce this change to the accordion component will follow.

**Example implementation**
Closed accordion toggle within an accordion:
![image](https://github.com/user-attachments/assets/535d168f-b75f-48cc-89c9-82f16f531d50)

Open accordion toggle within an accordion:
![image](https://github.com/user-attachments/assets/388413b3-67ed-4c9c-9fec-d06c4cade72f)


