### PR TITLE
feat: add validation for default value for enquiry form-types

### DIFF
--- a/lib/canvas/validators/schema_attribute.rb
+++ b/lib/canvas/validators/schema_attribute.rb
@@ -37,7 +37,7 @@ module Canvas
         "date" => SchemaAttribute::Date,
         "experience_date" => SchemaAttribute::ExperienceDate,
         "experience_slot" => SchemaAttribute::ExperienceSlot,
-        "enquiry_form" => SchemaAttribute::Base,
+        "enquiry_form" => SchemaAttribute::EnquiryForm,
       }.freeze
       RESERVED_NAMES = %w[
         page

--- a/lib/canvas/validators/schema_attributes/enquiry_form.rb
+++ b/lib/canvas/validators/schema_attributes/enquiry_form.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Canvas
+  module Validator
+    class SchemaAttribute
+      # :documented:
+      # Attribute validations specific to enquiry form-type variables.
+      class EnquiryForm < Base
+        ALLOWED_DEFAULT_VALUES = %w[random].freeze
+
+        def validate
+          super &&
+            ensure_default_values_are_valid
+        end
+
+        private
+
+        def permitted_values_for_default_key
+          if attribute["array"]
+            Array
+          else
+            String
+          end
+        end
+
+        def ensure_default_values_are_valid
+          return true unless attribute.key?("default")
+
+          if attribute["array"]
+            attribute["default"].all? { |value| default_value_is_valid?(value) }
+          else
+            default_value_is_valid?(attribute["default"])
+          end
+        end
+
+        def default_value_is_valid?(value)
+          value = value.downcase
+          if !ALLOWED_DEFAULT_VALUES.include?(value)
+            @errors << "\"default\" for enquiry form-type variables must be "\
+                       "one of: #{ALLOWED_DEFAULT_VALUES.join(', ')}"
+            false
+          else
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.10.0"
+  VERSION = "4.11.0"
 end

--- a/spec/lib/canvas/validators/schema_attributes/enquiry_form_spec.rb
+++ b/spec/lib/canvas/validators/schema_attributes/enquiry_form_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+describe Canvas::Validator::SchemaAttribute::EnquiryForm do
+  subject(:validator) {
+    Canvas::Validator::SchemaAttribute::EnquiryForm.new(attribute)
+  }
+
+  describe "#validate" do
+    describe "validating an optional 'default' key" do
+      let(:attribute) {
+        {
+          "name" => "my_form",
+          "type" => "enquiry_form",
+          "default" => default_value
+        }
+      }
+
+      context "when unknown default value is provided" do
+        let(:default_value) { "FAIL" }
+
+        it "adds an error and fails the validation" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include(
+            "\"default\" for enquiry form-type variables must be one of: random"
+          )
+        end
+      end
+
+      context "when `random` default value is provided" do
+        let(:default_value) { "Random" }
+
+        it "passes the validation" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+
+      context "when `default` is an array of invalid options" do
+        let(:attribute) {
+          {
+            "name" => "my_form",
+            "type" => "enquiry_form",
+            "array" => true,
+            "default" => %w[random modnar]
+          }
+        }
+        it "returns false" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include(
+            "\"default\" for enquiry form-type variables must be one of: random"
+          )
+        end
+      end
+
+      context "when `default` is an array of valid options" do
+        let(:attribute) {
+          {
+            "name" => "my_form",
+            "type" => "enquiry_form",
+            "array" => true,
+            "default" => %w[Random random]
+          }
+        }
+        it "returns true" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, the `default` value for an `enquiry_form` type is handled by the base validator, which means you can input any value and the code block will still save as normal (although nothing will be populated as the default).

This change adds specific validation for `enquiry_form` types to ensure that the only accepted value for `default` is `random`.

This is in preparation for an upcoming change that will allow all enquiry form blocks in the themes to be pre-populated with a random enquiry form.

**To test locally**
1. Clone the branch
2. Update the Gemfile in your local Rails app to specify the local path (eg. `path: "/Users/samanthalind/Documents/easol-canvas"`).
3. Add a new block on [this blank page](http://experiencetestcompany.easol.test/admin/site_builder/sites/87633416-9360-4a5c-92c4-8e4d83212d15/pages/blank-page-12) in staging with the following custom HTML:

```
---
attributes:
  enquiry_form:
    type: enquiry_form
    label: Form
    default: test
---

{% render 'enquiry-form-v4',
  enquiry_form: enquiry_form,
%}
```

4. On save, you should see the below error message:
<img width="727" alt="Screenshot 2024-08-06 at 10 38 35" src="https://github.com/user-attachments/assets/ea68a513-66a3-439e-9a6f-e1dc65b3d084">

5. Update the default value to `random`, and the block should save successfully.
