### PR TITLE
LS-136 Introduce a package pricing liquid tag

### DIFF
--- a/lib/canvas/checks/valid_liquid_check.rb
+++ b/lib/canvas/checks/valid_liquid_check.rb
@@ -44,6 +44,7 @@ module Canvas
       register_tag("experience_slot_search", ::Liquid::Block)
       register_tag("experience_slot_calendar", ::Liquid::Block)
       register_tag("package_availability", Liquid::Block)
+      register_tag("package_price", Liquid::Block)
       register_tag("input", ::Liquid::Tag)
       register_tag("label", ::Liquid::Tag)
       register_tag("package_step_product_search", ::Liquid::Block)

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.12.1"
+  VERSION = "4.13.0"
 end


### PR DESCRIPTION
We are introduce a new `package_price` tag in https://github.com/easolhq/easol/pull/15371.

This allows the validator to accept the new tag.