### PR TITLE
Register dynamic_package_booking_price tag

### DIFF
--- a/lib/canvas/checks/valid_liquid_check.rb
+++ b/lib/canvas/checks/valid_liquid_check.rb
@@ -41,6 +41,7 @@ module Canvas
       register_tag("currency_switcher", ::Liquid::Tag)
       register_tag("json", ::Liquid::Block)
       register_tag("variant_pricing", ::Liquid::Tag)
+      register_tag("dynamic_package_booking_price", ::Liquid::Tag)
       register_tag("experience_slot_search", ::Liquid::Block)
       register_tag("experience_slot_calendar", ::Liquid::Block)
       register_tag("package_availability", Liquid::Block)

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.13.0"
+  VERSION = "4.13.1"
 end


### PR DESCRIPTION
This is a new tag we're using to return the cheapest price for a given package step product.