### PR TITLE
Move from buildkite to Github actions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,0 @@
-steps:
-  - label: ":rspec: Ruby specs"
-    command:
-      - "bundle"
-      - "bundle exec rspec"
-      - "bundle exec rubocop"
-    plugins:
-      - docker#v3.9.0:
-          image: ruby:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Run RSpec tests
+on: [push]
+jobs:
+  run-rspec-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.4
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rspec
+      - name: Rubocop
+        run: bundle exec rubocop

--- a/spec/lib/canvas/checks/valid_json_check_spec.rb
+++ b/spec/lib/canvas/checks/valid_json_check_spec.rb
@@ -15,11 +15,11 @@ describe Canvas::ValidJsonCheck do
     it "adds an offense when a file contains invalid json" do
       copy_example_directory("vagabond")
       subject.run
-      message = "unexpected token at 'This is an invalid custom type."
+      message_pattern = /Invalid JSON: .+ - \nunexpected \w+(?:: | at )'This is an invalid custom type\.\n'/
 
       expect(subject.offenses).to match_array(
         [
-          have_attributes(message: include(message.squeeze("\n")))
+          have_attributes(message: match(message_pattern))
         ]
       )
     end


### PR DESCRIPTION
So that we can kill Buildkite once and for all we need to migrate this app over to GH actions as well