### PR TITLE
Bump json-schema gem to v4

### DIFF
--- a/canvas.gemspec
+++ b/canvas.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency "cli-ui", "~> 1.5"
   s.add_dependency "liquid", "~> 5.3"
   s.add_dependency "dartsass-rails", "~> 0.4"
-  s.add_dependency "json-schema", "~> 3"
+  s.add_dependency "json-schema", "~> 4"
 end


### PR DESCRIPTION
A gem we're trying to install on the Easol app has a dependency on json-schema v4.

This looks safe to bump.