### PR TITLE
Allow html elements to be set by liquid variables

### DIFF
--- a/lib/canvas/validators/html.rb
+++ b/lib/canvas/validators/html.rb
@@ -31,10 +31,10 @@ module Canvas
       end
 
       # We want to strip out the liquid tags and replace them with the
-      # same number of empty space characters, so that the linter
-      # reports the correct character number.
+      # same number of characters, so that the linter reports the
+      # correct character number.
       def strip_out_liquid(html)
-        html.gsub(LIQUID_TAG_OR_VARIABLE) { |tag| " " * tag.size }
+        html.gsub(LIQUID_TAG_OR_VARIABLE) { |tag| "x" * tag.size }
       end
 
       # We want to strip out the front matter and replace it

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.15.0"
+  VERSION = "4.16.0"
 end

--- a/spec/lib/canvas/checks/valid_html_check_spec.rb
+++ b/spec/lib/canvas/checks/valid_html_check_spec.rb
@@ -17,7 +17,7 @@ describe Canvas::ValidHtmlCheck do
       message = <<~MESSAGE.chop
         Invalid HTML: blocks/hero/block.liquid - \n
         14:16: ERROR: Start tag of nonvoid HTML element ends with '/>', use '>'.
-        <h1>           <foo/>
+        <h1>xxxxxxxxxxx<foo/>
                        ^
       MESSAGE
 

--- a/spec/lib/canvas/validators/html_spec.rb
+++ b/spec/lib/canvas/validators/html_spec.rb
@@ -44,5 +44,13 @@ describe Canvas::Validator::Html do
 
       expect(Canvas::Validator::Html.new(html).validate).to be_truthy
     end
+
+    it "strips out liquid" do
+      html = <<-LIQUID
+        <{{ tag | default: 'div' }}>This is valid html</{{ tag | default: 'div' }}>
+      LIQUID
+
+      expect(Canvas::Validator::Html.new(html).validate).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
This is something our theme devs want to do. Previously, we replaced liquid variables with empty spaces, which is fine for most uses but when it's used directly in the html tag this results in: `ERROR: Invalid first character of tag name ' '.`

By changing this to `x` we can keep the same number of characters but allow for liquid variables to be used in the tag.

Minor version update - adding functionality in a backward compatible manner.