### PR TITLE
fix: extend html validation to treat liquid tags and variables differ…

### DIFF
--- a/lib/canvas/validators/html.rb
+++ b/lib/canvas/validators/html.rb
@@ -34,7 +34,10 @@ module Canvas
       # same number of characters, so that the linter reports the
       # correct character number.
       def strip_out_liquid(html)
-        html.gsub(LIQUID_TAG_OR_VARIABLE) { |tag| "x" * tag.size }
+        # First replace liquid tags with spaces
+        html = html.gsub(LIQUID_TAG) { |tag| " " * tag.size }
+        # Then replace liquid variables with x's
+        html.gsub(LIQUID_VARIABLE) { |var| "x" * var.size }
       end
 
       # We want to strip out the front matter and replace it

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.16.0"
+  VERSION = "4.17.0"
 end

--- a/spec/lib/canvas/validators/html_spec.rb
+++ b/spec/lib/canvas/validators/html_spec.rb
@@ -53,4 +53,29 @@ describe Canvas::Validator::Html do
       expect(Canvas::Validator::Html.new(html).validate).to be_truthy
     end
   end
+
+  describe "#strip_out_liquid" do
+    it "handles liquid tags and variables differently" do
+      html = <<~LIQUID
+        <a href="{{ variable }}" {% if condition %}target="_blank"{% endif %}>Link</a>
+      LIQUID
+      validator = described_class.new(html)
+      stripped = validator.send(:strip_out_liquid, html).chomp
+      expect(stripped).to eq(
+        '<a href="xxxxxxxxxxxxxx"                   target="_blank"           >Link</a>'
+      )
+    end
+
+    it "validates html with liquid tags and variables" do
+      html = <<~LIQUID
+        <div class="{% if condition %}active{% endif %}">
+          <h1>{{ title }}</h1>
+          <p>{{ content }}</p>
+        </div>
+      LIQUID
+
+      validator = described_class.new(html)
+      expect(validator.validate).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This change extends the current HTML validation to treat liquid tags and variables differently.

We were previously replacing both of these with blanks, which was causing issues when liquid variables were used within HTML tags. We then replaced both with 'x's; however this is now causing issues with the liquid tags.

This change keeps the blanks as normal for liquid tags, but replaces the content of any variables with 'x' instead, which should deliver the result we're after.

For example
 `<a href="{{ optin_link.url }}" {% if optin_link.new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>`
becomes:
`<a href="xxxxxxxxxxxxxxxxxxx"                           target="_blank" rel="noopener noreferrer"           >`