### PR TITLE
Modifier Variable Type

### DIFF
--- a/lib/canvas/constants.rb
+++ b/lib/canvas/constants.rb
@@ -16,6 +16,7 @@ module Canvas
       color
       image
       link
+      modifier
       number
       page
       post

--- a/lib/canvas/validators/schema_attribute.rb
+++ b/lib/canvas/validators/schema_attribute.rb
@@ -20,6 +20,7 @@ module Canvas
     class SchemaAttribute
       VALIDATORS = {
         "image" => SchemaAttribute::Image,
+        "modifier" => SchemaAttribute::Modifier,
         "product" => SchemaAttribute::Product,
         "post" => SchemaAttribute::Post,
         "page" => SchemaAttribute::Page,

--- a/lib/canvas/validators/schema_attributes/modifier.rb
+++ b/lib/canvas/validators/schema_attributes/modifier.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Canvas
+  module Validator
+    class SchemaAttribute
+      # :documented:
+      # Attribute validations specific to modifier-type variables.
+      # Modifier drops expose name and id properties for use in site builder schemas.
+      class Modifier < Base
+        ALLOWED_DEFAULT_VALUES = %w[random].freeze
+
+        def validate
+          super &&
+            ensure_default_values_are_valid
+        end
+
+        private
+
+        def permitted_values_for_default_key
+          if attribute["array"]
+            Array
+          else
+            String
+          end
+        end
+
+        def ensure_default_values_are_valid
+          return true unless attribute.key?("default")
+
+          if attribute["array"]
+            attribute["default"].all? { |value| default_value_is_valid?(value) }
+          else
+            default_value_is_valid?(attribute["default"])
+          end
+        end
+
+        def default_value_is_valid?(value)
+          value = value.downcase
+          if !ALLOWED_DEFAULT_VALUES.include?(value)
+            @errors << %["default" for modifier-type variables must be one of: #{ALLOWED_DEFAULT_VALUES.join(', ')}]
+            false
+          else
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.17.0"
+  VERSION = "4.18.0"
 end

--- a/spec/lib/canvas/checks/valid_json_check_spec.rb
+++ b/spec/lib/canvas/checks/valid_json_check_spec.rb
@@ -15,7 +15,7 @@ describe Canvas::ValidJsonCheck do
     it "adds an offense when a file contains invalid json" do
       copy_example_directory("vagabond")
       subject.run
-      message_pattern = /Invalid JSON: .+ - \nunexpected \w+(?:: | at )'This is an invalid custom type\.\n'/
+      message_pattern = /Invalid JSON: .*types\/card\.json - \nunexpected character: 'This' at line 1 column 1/
 
       expect(subject.offenses).to match_array(
         [

--- a/spec/lib/canvas/validators/schema_attributes/modifier_spec.rb
+++ b/spec/lib/canvas/validators/schema_attributes/modifier_spec.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+describe Canvas::Validator::SchemaAttribute::Modifier do
+  subject(:validator) { described_class.new(attribute) }
+
+  describe "#validate" do
+    context "when the attribute has only required keys" do
+      let(:attribute) {
+        {
+          "name" => "my_modifier",
+          "type" => "modifier"
+        }
+      }
+
+      it "returns true" do
+        expect(validator.validate).to eq(true)
+      end
+    end
+
+    context "when the attribute has optional keys" do
+      let(:attribute) {
+        {
+          "name" => "featured_modifier",
+          "type" => "modifier",
+          "label" => "Featured Modifier",
+          "hint" => "Select a modifier to feature",
+          "group" => "content"
+        }
+      }
+
+      it "returns true" do
+        expect(validator.validate).to eq(true)
+      end
+    end
+
+    describe "validating an optional 'default' key" do
+      context "when unknown default value is provided" do
+        let(:attribute) {
+          {
+            "name" => "my_modifier",
+            "type" => "modifier",
+            "default" => "invalid_value"
+          }
+        }
+
+        it "adds an error and fails the validation" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include(
+            "\"default\" for modifier-type variables must be one of: random"
+          )
+        end
+      end
+
+      context "when 'random' default value is provided" do
+        let(:attribute) {
+          {
+            "name" => "my_modifier",
+            "type" => "modifier",
+            "default" => "random"
+          }
+        }
+
+        it "passes the validation" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+
+      context "when 'Random' (capitalized) default value is provided" do
+        let(:attribute) {
+          {
+            "name" => "my_modifier",
+            "type" => "modifier",
+            "default" => "Random"
+          }
+        }
+
+        it "passes the validation" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+
+      context "when modifier is an array" do
+        context "when 'default' is an array of invalid options" do
+          let(:attribute) {
+            {
+              "name" => "my_modifiers",
+              "type" => "modifier",
+              "array" => true,
+              "default" => %w[random invalid_value]
+            }
+          }
+
+          it "returns false" do
+            expect(validator.validate).to eq(false)
+            expect(validator.errors).to include(
+              "\"default\" for modifier-type variables must be one of: random"
+            )
+          end
+        end
+
+        context "when 'default' is an array of valid options" do
+          let(:attribute) {
+            {
+              "name" => "my_modifiers",
+              "type" => "modifier",
+              "array" => true,
+              "default" => %w[Random random]
+            }
+          }
+
+          it "returns true" do
+            expect(validator.validate).to eq(true)
+          end
+        end
+
+        context "when 'default' is not an array for array type" do
+          let(:attribute) {
+            {
+              "name" => "my_modifiers",
+              "type" => "modifier",
+              "array" => true,
+              "default" => "random"
+            }
+          }
+
+          it "returns false" do
+            expect(validator.validate).to eq(false)
+            expect(validator.errors).to include(
+              "\"default\" is a String, expected Array"
+            )
+          end
+        end
+      end
+
+      context "when modifier is not an array" do
+        context "when 'default' is an array for non-array type" do
+          let(:attribute) {
+            {
+              "name" => "my_modifier",
+              "type" => "modifier",
+              "default" => ["random"]
+            }
+          }
+
+          it "returns false" do
+            expect(validator.validate).to eq(false)
+            expect(validator.errors).to include(
+              "\"default\" is a Array, expected String"
+            )
+          end
+        end
+      end
+    end
+
+    describe "array support" do
+      context "when modifier is defined as an array" do
+        let(:attribute) {
+          {
+            "name" => "modifier_list",
+            "type" => "modifier",
+            "array" => true
+          }
+        }
+
+        it "returns true" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+
+      context "when modifier array has a valid default" do
+        let(:attribute) {
+          {
+            "name" => "modifier_list",
+            "type" => "modifier",
+            "array" => true,
+            "default" => ["random"]
+          }
+        }
+
+        it "returns true" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+    end
+
+    describe "inheritance from base validator" do
+      context "when missing required 'name' key" do
+        let(:attribute) {
+          {
+            "type" => "modifier"
+          }
+        }
+
+        it "returns false with errors" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include("Missing required keys: name")
+        end
+      end
+
+      context "when missing required 'type' key" do
+        let(:attribute) {
+          {
+            "name" => "my_modifier"
+          }
+        }
+
+        it "returns false with errors" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include("Missing required keys: type")
+        end
+      end
+
+      context "when using unrecognized keys" do
+        let(:attribute) {
+          {
+            "name" => "my_modifier",
+            "type" => "modifier",
+            "invalid_key" => "value"
+          }
+        }
+
+        it "returns false with errors" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include("Unrecognized keys: invalid_key")
+        end
+      end
+
+      context "when name is not a string" do
+        let(:attribute) {
+          {
+            "name" => 123,
+            "type" => "modifier"
+          }
+        }
+
+        it "returns false with errors" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include("\"name\" is a Integer, expected String")
+        end
+      end
+
+      context "when array is not a boolean" do
+        let(:attribute) {
+          {
+            "name" => "my_modifier",
+            "type" => "modifier",
+            "array" => "yes"
+          }
+        }
+
+        it "returns false with errors" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include("\"array\" is 'yes', expected one of: true, false")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `modifier` variable type has been added to
Canvas and can be used in site builder schemas.

- Added `modifier` to `Canvas::Constants::PRIMITIVE_TYPES`
- Created `Canvas::Validator::SchemaAttribute::Modifier` validator class
- Supports `random` as a default value (similar to product/variant types)
- Can be used as single values or arrays
- Follows the same validation patterns as other Canvas variable types