### PR TITLE
Enable nested custom types in Canvas validation

### DIFF
--- a/lib/canvas/checks/valid_custom_types_check.rb
+++ b/lib/canvas/checks/valid_custom_types_check.rb
@@ -6,9 +6,11 @@ module Canvas
   # custom types that are defined in the /types directory.
   class ValidCustomTypesCheck < Check
     def run
+      custom_types = Canvas::FetchCustomTypes.call
+
       custom_type_files.each do |filename|
         schema = extract_json(filename)
-        validator = Validator::CustomType.new(schema: schema)
+        validator = Validator::CustomType.new(schema: schema, custom_types: custom_types)
 
         next if validator.validate
 

--- a/lib/canvas/validators/custom_type.rb
+++ b/lib/canvas/validators/custom_type.rb
@@ -26,10 +26,11 @@ module Canvas
     class CustomType
       REQUIRED_KEYS = %w[key name attributes].freeze
 
-      attr_reader :schema, :errors
+      attr_reader :schema, :errors, :custom_types
 
-      def initialize(schema:)
+      def initialize(schema:, custom_types: [])
         @schema = schema
+        @custom_types = custom_types
         @errors = []
       end
 
@@ -127,7 +128,7 @@ module Canvas
         schema["attributes"].each do |attribute_schema|
           attr_validator = Validator::SchemaAttribute.new(
             attribute: attribute_schema,
-            custom_types: []
+            custom_types: custom_types
           )
           next if attr_validator.validate
 

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.18.0"
+  VERSION = "4.19.0"
 end

--- a/spec/lib/canvas/validators/custom_type_spec.rb
+++ b/spec/lib/canvas/validators/custom_type_spec.rb
@@ -2,8 +2,10 @@
 
 describe Canvas::Validator::CustomType do
   subject(:validator) {
-    Canvas::Validator::CustomType.new(schema: schema)
+    Canvas::Validator::CustomType.new(schema: schema, custom_types: custom_types)
   }
+
+  let(:custom_types) { [] }
 
   describe "#validate" do
     context "when schema has required keys" do
@@ -246,6 +248,49 @@ describe Canvas::Validator::CustomType do
       it "returns false with errors" do
         expect(validator.validate).to eq(false)
         expect(validator.errors).to include("The first attribute cannot be an array")
+      end
+    end
+
+    context "when attributes reference another custom type" do
+      let(:custom_types) { [referenced_type, schema] }
+
+      let(:referenced_type) {
+        {
+          "key" => "faq",
+          "name" => "Faq",
+          "attributes" => [
+            {
+              "name" => "question",
+              "type" => "string"
+            },
+            {
+              "name" => "answer",
+              "type" => "text"
+            }
+          ]
+        }
+      }
+
+      let(:schema) {
+        {
+          "key" => "faq_list",
+          "name" => "Faq List",
+          "attributes" => [
+            {
+              "name" => "title",
+              "type" => "string"
+            },
+            {
+              "name" => "items",
+              "type" => "faq",
+              "array" => true
+            }
+          ]
+        }
+      }
+
+      it "allows nested custom types" do
+        expect(validator.validate).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Previously, custom types could not reference other custom types within their attribute definitions. This limitation forced workarounds and made it difficult to organise block options logically.

The issue was that `Canvas::Validator::CustomType` was passing an empty array to `SchemaAttribute` when validating attributes, preventing it from recognising custom type references. While `BlockSchema` already successfully used custom types by passing the full `custom_types` array, the same pattern was not applied within custom type validation.

This change updates the validation flow to pass available custom types through the validation chain, allowing nested custom type references. 

Changes:
- Updated `Canvas::Validator::CustomType` to accept `custom_types` parameter in initializer
- Modified `Canvas::ValidCustomTypesCheck` to fetch all custom types upfront and pass them to each validator instance
- Updated `CustomType#ensure_attributes_are_valid` to pass the `custom_types` array instead of an empty array to `SchemaAttribute`
- Added test coverage for nested custom type validation
- Bumped the gem version