### PR TITLE
Introduce packages_search_and_calendar tag

### DIFF
--- a/lib/canvas/checks/valid_liquid_check.rb
+++ b/lib/canvas/checks/valid_liquid_check.rb
@@ -30,28 +30,30 @@ module Canvas
       ::Liquid::Template.register_tag(name, klass)
     end
 
-    # These are the tags that we define in the Rails app. If we add a new custom tag
-    # in the Rails app, we'll need to register it here.
+    # These are the tags that we define in the Rails app. If we add a
+    # new custom tag in the Rails app, we'll need to register it here.
     def register_tags!
-      register_tag("form", ::Liquid::Block)
-      register_tag("product_search", ::Liquid::Block)
-      register_tag("easol_badge", ::Liquid::Tag)
-      register_tag("accommodation_availability", ::Liquid::Block)
-      register_tag("cache", ::Liquid::Block)
-      register_tag("currency_switcher", ::Liquid::Tag)
-      register_tag("json", ::Liquid::Block)
-      register_tag("variant_pricing", ::Liquid::Tag)
-      register_tag("dynamic_package_booking_price", ::Liquid::Tag)
+      # Single statement non-block tags, no closing tag required.
       register_tag("cart_timer", ::Liquid::Tag)
       register_tag("cart_timer_add_time", ::Liquid::Tag)
-      register_tag("experience_slot_search", ::Liquid::Block)
-      register_tag("experience_slot_calendar", ::Liquid::Block)
-      register_tag("package_availability", Liquid::Block)
-      register_tag("package_price", Liquid::Block)
+      register_tag("currency_switcher", ::Liquid::Tag)
+      register_tag("dynamic_package_booking_price", ::Liquid::Tag)
+      register_tag("easol_badge", ::Liquid::Tag)
       register_tag("input", ::Liquid::Tag)
       register_tag("label", ::Liquid::Tag)
+      register_tag("variant_pricing", ::Liquid::Tag)
+      # Tags wrapping nested content with a closing tag.
+      register_tag("accommodation_availability", ::Liquid::Block)
+      register_tag("cache", ::Liquid::Block)
+      register_tag("experience_slot_calendar", ::Liquid::Block)
+      register_tag("experience_slot_search", ::Liquid::Block)
+      register_tag("form", ::Liquid::Block)
+      register_tag("json", ::Liquid::Block)
+      register_tag("package_availability", ::Liquid::Block)
+      register_tag("package_price", ::Liquid::Block)
       register_tag("package_step_product_search", ::Liquid::Block)
       register_tag("packages_search_and_calendar", ::Liquid::Block)
+      register_tag("product_search", ::Liquid::Block)
     end
   end
 end

--- a/lib/canvas/checks/valid_liquid_check.rb
+++ b/lib/canvas/checks/valid_liquid_check.rb
@@ -51,6 +51,7 @@ module Canvas
       register_tag("input", ::Liquid::Tag)
       register_tag("label", ::Liquid::Tag)
       register_tag("package_step_product_search", ::Liquid::Block)
+      register_tag("packages_search_and_calendar", ::Liquid::Block)
     end
   end
 end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.19.0"
+  VERSION = "4.20.0"
 end


### PR DESCRIPTION
We're calling it packages plural, unlike the other `package_*` tags because it accepts multiple packages.