### PR TITLE
Minor: Validate new "visible_if" field in custom types

### DIFF
--- a/lib/canvas/validators/schema_attributes/base.rb
+++ b/lib/canvas/validators/schema_attributes/base.rb
@@ -55,7 +55,8 @@ module Canvas
             "array" => [true, false],
             "label" => String,
             "hint" => String,
-            "group" => %w[content layout design mobile]
+            "group" => %w[content layout design mobile],
+            "visible_if" => String
           }
         end
 

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.20.0"
+  VERSION = "4.21.0"
 end

--- a/spec/lib/canvas/validators/schema_attributes/base_spec.rb
+++ b/spec/lib/canvas/validators/schema_attributes/base_spec.rb
@@ -57,6 +57,20 @@ describe Canvas::Validator::SchemaAttribute::Base do
       end
     end
 
+    context "when using visible_if key" do
+      let(:attribute) {
+        {
+          "name" => "button_content",
+          "type" => "button_content_v1",
+          "visible_if" => "show_button"
+        }
+      }
+
+      it "returns true" do
+        expect(validator.validate).to eq(true)
+      end
+    end
+
     context "when group is not from permitted list of values" do
       let(:attribute) {
         {


### PR DESCRIPTION
The `visible_if` addition is:
- New functionality (themes can now use `visible_if` in custom type schemas)
- Fully backward compatible (existing schemas without `visible_if` continue to work)
- Non-breaking (nothing existing breaks)