### PR TITLE
feat: extend canvas to accept new custom_type field

### DIFF
--- a/lib/canvas/validators/custom_type.rb
+++ b/lib/canvas/validators/custom_type.rb
@@ -25,6 +25,7 @@ module Canvas
     #
     class CustomType
       REQUIRED_KEYS = %w[key name attributes].freeze
+      OPTIONAL_KEYS = %w[layout].freeze
 
       attr_reader :schema, :errors, :custom_types
 
@@ -43,7 +44,8 @@ module Canvas
           ensure_key_value_is_not_reserved &&
           ensure_no_duplicate_attributes &&
           ensure_attributes_are_valid &&
-          ensure_first_attribute_not_array
+          ensure_first_attribute_not_array &&
+          ensure_layout_is_valid
 
         errors.empty?
       end
@@ -66,7 +68,7 @@ module Canvas
       end
 
       def ensure_no_unrecognized_keys
-        unrecognized_keys = schema.keys - REQUIRED_KEYS
+        unrecognized_keys = schema.keys - REQUIRED_KEYS - OPTIONAL_KEYS
         return true if unrecognized_keys.empty?
 
         @errors << "Unrecognized keys: #{unrecognized_keys.join(', ')}"
@@ -143,6 +145,16 @@ module Canvas
         return true if first_attribute.nil? || first_attribute["array"] != true
 
         @errors << "The first attribute cannot be an array"
+        false
+      end
+
+      def ensure_layout_is_valid
+        return true unless schema["layout"]
+
+        layout_validator = CustomTypeLayoutSchema.new(schema:)
+        return true if layout_validator.validate
+
+        @errors += layout_validator.errors
         false
       end
     end

--- a/lib/canvas/validators/custom_type_layout_schema.rb
+++ b/lib/canvas/validators/custom_type_layout_schema.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "json"
+require "json-schema"
+
+module Canvas
+  module Validator
+    # :documented:
+    # This class is used to validate a layout definition for a custom type.
+    # Custom type layouts use a flat array of elements (unlike block layouts which use tabs).
+    #
+    # Example of a valid custom type layout definition:
+    # {
+    #   "attributes" => [
+    #     { "name" => "question", "type" => "string" },
+    #     { "name" => "answer", "type" => "text" },
+    #     { "name" => "show_icon", "type" => "boolean" }
+    #   ],
+    #   "layout" => [
+    #     "question",
+    #     {
+    #       "type" => "accordion",
+    #       "label" => "Advanced",
+    #       "elements" => [
+    #         "answer",
+    #         { "type" => "attribute", "name" => "show_icon" }
+    #       ]
+    #     }
+    #   ]
+    # }
+    class CustomTypeLayoutSchema
+      attr_reader :errors
+
+      def initialize(schema:)
+        @schema = schema
+        @errors = []
+      end
+
+      def validate
+        @errors = []
+
+        if ensure_valid_format
+          ensure_no_unrecognized_keys
+          ensure_no_duplicate_keys
+          ensure_accordion_toggles_are_valid
+        end
+
+        @errors.empty?
+      end
+
+      private
+
+      attr_reader :schema
+
+      def ensure_no_duplicate_keys
+        attributes = fetch_all_attribute_names
+        duplicates =
+          attributes
+            .group_by { |(key)| key }
+            .filter { |_key, usage| usage.size > 1 }
+
+        return if duplicates.empty?
+
+        duplicates.each do |attribute, usage|
+          @errors << "Duplicated attribute key `#{attribute}` found. "\
+                     "Location: #{usage.map { |(_, location)| location }.join(', ')}"
+        end
+      end
+
+      def ensure_no_unrecognized_keys
+        attributes = fetch_all_attribute_names
+        defined_attributes = schema_attributes.map { |attr| normalize_attribute(attr["name"]) }
+
+        attributes.each do |attribute, location|
+          unless defined_attributes.include?(attribute)
+            @errors << "Unrecognized attribute `#{attribute}`. Location: #{location}"
+          end
+        end
+      end
+
+      # @return [Array<Array(String, String)>] an array of all the attribute names that
+      #         are mentioned in the layout schema, along with its path. The names are
+      #         normalized, i.e. downcased.
+      def fetch_all_attribute_names
+        attributes = fetch_elements_of_type("attribute")
+        attributes.map do |(node, path)|
+          [
+            normalize_attribute(node.is_a?(Hash) ? node["name"] : node),
+            path
+          ]
+        end
+      end
+
+      # @param type [String] the element type to fetch
+      # @return [Array<Array(<Hash, String>, String)] an array of elements that match
+      #   the given type. Each element is an array containing the node and its path.
+      def fetch_elements_of_type(type)
+        elements = []
+
+        fetch_element = lambda { |node, path|
+          if type == "attribute" && node.is_a?(String)
+            elements << [node, path]
+          elsif node.is_a?(Hash) && node["type"] == type
+            elements << [node, path]
+          end
+
+          if node.is_a?(Hash) && node.key?("elements")
+            node["elements"].each_with_index do |element, i|
+              current_path = "#{path}/elements/#{i}"
+              fetch_element.call(element, current_path)
+            end
+          end
+        }
+
+        # Flat layout: iterate directly over layout elements
+        layout_schema.each_with_index do |element, i|
+          current_path = "layout/#{i}"
+          fetch_element.call(element, current_path)
+        end
+
+        elements
+      end
+
+      def ensure_valid_format
+        result = JSON::Validator.fully_validate(
+          schema_definition,
+          { "layout" => layout_schema },
+          strict: true,
+          clear_cache: true
+        )
+
+        return true if result.empty?
+
+        @errors += result
+        false
+      end
+
+      def ensure_accordion_toggles_are_valid
+        accordion_toggles = fetch_elements_of_type("accordion_toggle")
+        accordion_toggles.each do |accordion_toggle, location|
+          toggle_attribute = schema_attributes.detect { |attr|
+            attr["name"] == accordion_toggle["toggle_attribute"]
+          }
+
+          if toggle_attribute.nil?
+            @errors << "The toggle_attribute in accordion_toggle is unrecognized. Location: #{location}"
+          elsif toggle_attribute["type"]&.downcase != "boolean"
+            @errors << "The toggle_attribute in accordion_toggle must be a boolean. Location: #{location}"
+          end
+        end
+      end
+
+      def layout_schema
+        schema["layout"] || []
+      end
+
+      def schema_definition
+        File.read(
+          File.join(File.dirname(__FILE__), "../../../", "schema_definitions", "custom_type_layout.json")
+        )
+      end
+
+      def normalize_attribute(name)
+        name.to_s.strip.downcase
+      end
+
+      def schema_attributes
+        schema["attributes"] || []
+      end
+    end
+  end
+end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.20.0"
+  VERSION = "4.21.0"
 end

--- a/schema_definitions/custom_type_layout.json
+++ b/schema_definitions/custom_type_layout.json
@@ -1,0 +1,79 @@
+{
+  "type": "object",
+  "properties": {
+    "layout": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          { "$ref": "#/$defs/accordion" },
+          { "$ref": "#/$defs/accordion_toggle" },
+          { "$ref": "#/$defs/attribute" }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "accordion": {
+      "type": "object",
+      "required": ["label", "type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "accordion"
+        },
+        "label": {
+          "type": "string"
+        },
+        "elements": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "type": "string" },
+              { "$ref": "#/$defs/accordion_toggle" },
+              { "$ref": "#/$defs/attribute" }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "accordion_toggle": {
+      "type": "object",
+      "required": ["type", "toggle_attribute", "elements"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "accordion_toggle"
+        },
+        "toggle_attribute": {
+          "type": "string"
+        },
+        "elements": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "type": "string" },
+              { "$ref": "#/$defs/attribute" }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "attribute": {
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "attribute"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/spec/lib/canvas/validators/custom_type_layout_schema_spec.rb
+++ b/spec/lib/canvas/validators/custom_type_layout_schema_spec.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+describe Canvas::Validator::CustomTypeLayoutSchema do
+  subject(:validator) {
+    Canvas::Validator::CustomTypeLayoutSchema.new(schema:)
+  }
+
+  let(:attributes) do
+    [
+      { "name" => "question", "type" => "string" },
+      { "name" => "answer", "type" => "text" },
+      { "name" => "show_icon", "type" => "boolean" },
+      { "name" => "icon_color", "type" => "color" }
+    ]
+  end
+
+  describe "on schema format validation" do
+    describe "when layout is empty" do
+      let(:schema) do
+        { "attributes" => attributes }
+      end
+
+      it "returns true" do
+        expect(validator.validate).to be_truthy
+      end
+    end
+
+    describe "when format is valid with simple elements" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => %w[question answer]
+        }
+      end
+
+      it "returns true" do
+        expect(validator.validate).to be_truthy
+      end
+    end
+
+    describe "when format is valid with multiple elements" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => ["question", "answer", "show_icon"]
+        }
+      end
+
+      it "returns true" do
+        expect(validator.validate).to be_truthy
+      end
+    end
+
+    describe "when format is valid with accordion" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => [
+            "question",
+            {
+              "type" => "accordion",
+              "label" => "Advanced",
+              "elements" => [
+                "answer",
+                { "type" => "attribute", "name" => "show_icon" }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "returns true" do
+        expect(validator.validate).to be_truthy
+      end
+    end
+
+    describe "when format is valid with accordion_toggle" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => [
+            "question",
+            {
+              "type" => "accordion_toggle",
+              "toggle_attribute" => "show_icon",
+              "elements" => [
+                "icon_color"
+              ]
+            }
+          ]
+        }
+      end
+
+      it "returns true" do
+        expect(validator.validate).to be_truthy
+      end
+    end
+
+    describe "when element has invalid type" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => [
+            1234,
+            "question"
+          ]
+        }
+      end
+
+      it "returns false" do
+        expect(validator.validate).to be_falsey
+      end
+
+      it "contains errors" do
+        validator.validate
+        expect(validator.errors).to include(match("did not match any of the required schemas"))
+      end
+    end
+
+    describe "when accordion_toggle is missing toggle_attribute" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => [
+            {
+              "type" => "accordion_toggle",
+              "elements" => ["question"]
+            }
+          ]
+        }
+      end
+
+      it "returns false" do
+        expect(validator.validate).to be_falsey
+      end
+
+      it "contains errors" do
+        validator.validate
+        expect(validator.errors).to include(match("did not match any of the required schemas"))
+      end
+    end
+
+    describe "when element has unrecognized keys" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => [
+            {
+              "type" => "attribute",
+              "name" => "question",
+              "unknown_key" => "value"
+            }
+          ]
+        }
+      end
+
+      it "returns false" do
+        expect(validator.validate).to be_falsey
+      end
+
+      it "contains errors" do
+        validator.validate
+        expect(validator.errors).to include(match("contains additional properties"))
+      end
+    end
+  end
+
+  describe "on business rule validation" do
+    describe "when duplicated attribute keys are present" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => [
+            "question",
+            {
+              "type" => "accordion",
+              "label" => "Details",
+              "elements" => [
+                "question",
+                "answer"
+              ]
+            }
+          ]
+        }
+      end
+
+      it "returns false" do
+        expect(validator.validate).to be_falsey
+      end
+
+      it "contains errors" do
+        validator.validate
+        expect(validator.errors).to include(match("Duplicated attribute key `question` found"))
+      end
+    end
+
+    describe "when unrecognized attribute keys are present" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => [
+            "question",
+            "unknown_attribute"
+          ]
+        }
+      end
+
+      it "returns false" do
+        expect(validator.validate).to be_falsey
+      end
+
+      it "contains errors" do
+        validator.validate
+        expect(validator.errors).to include("Unrecognized attribute `unknown_attribute`. Location: layout/1")
+      end
+    end
+
+    describe "when accordion_toggle has unrecognized toggle_attribute" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => [
+            "question",
+            {
+              "type" => "accordion_toggle",
+              "toggle_attribute" => "unknown",
+              "elements" => ["answer"]
+            }
+          ]
+        }
+      end
+
+      it "returns false" do
+        expect(validator.validate).to be_falsey
+      end
+
+      it "contains errors" do
+        validator.validate
+        expect(validator.errors).to include("The toggle_attribute in accordion_toggle is unrecognized. Location: layout/1")
+      end
+    end
+
+    describe "when accordion_toggle has non-boolean toggle_attribute" do
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => [
+            "question",
+            {
+              "type" => "accordion_toggle",
+              "toggle_attribute" => "question",
+              "elements" => ["answer"]
+            }
+          ]
+        }
+      end
+
+      it "returns false" do
+        expect(validator.validate).to be_falsey
+      end
+
+      it "contains errors" do
+        validator.validate
+        expect(validator.errors).to include("The toggle_attribute in accordion_toggle must be a boolean. Location: layout/1")
+      end
+    end
+
+    describe "when accordion_toggle has boolean toggle_attribute with capital letter type" do
+      let(:attributes) do
+        [
+          { "name" => "question", "type" => "string" },
+          { "name" => "answer", "type" => "text" },
+          { "name" => "ENABLED", "type" => "Boolean" }
+        ]
+      end
+
+      let(:schema) do
+        {
+          "attributes" => attributes,
+          "layout" => [
+            "question",
+            {
+              "type" => "accordion_toggle",
+              "toggle_attribute" => "ENABLED",
+              "elements" => ["answer"]
+            }
+          ]
+        }
+      end
+
+      it "is valid" do
+        expect(validator.validate).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/lib/canvas/validators/custom_type_spec.rb
+++ b/spec/lib/canvas/validators/custom_type_spec.rb
@@ -293,5 +293,85 @@ describe Canvas::Validator::CustomType do
         expect(validator.validate).to eq(true)
       end
     end
+
+    context "when schema has a valid layout" do
+      let(:schema) {
+        {
+          "key" => "card",
+          "name" => "Card",
+          "attributes" => [
+            { "name" => "title", "type" => "string" },
+            { "name" => "description", "type" => "text" },
+            { "name" => "show_icon", "type" => "boolean" }
+          ],
+          "layout" => [
+            "title",
+            {
+              "type" => "accordion",
+              "label" => "Details",
+              "elements" => ["description"]
+            }
+          ]
+        }
+      }
+
+      it "returns true" do
+        expect(validator.validate).to eq(true)
+      end
+    end
+
+    context "when schema has layout with unrecognized attribute" do
+      let(:schema) {
+        {
+          "key" => "card",
+          "name" => "Card",
+          "attributes" => [
+            { "name" => "title", "type" => "string" }
+          ],
+          "layout" => ["title", "unknown_attr"]
+        }
+      }
+
+      it "returns false with errors" do
+        expect(validator.validate).to eq(false)
+        expect(validator.errors).to include("Unrecognized attribute `unknown_attr`. Location: layout/1")
+      end
+    end
+
+    context "when schema has layout with invalid format" do
+      let(:schema) {
+        {
+          "key" => "card",
+          "name" => "Card",
+          "attributes" => [
+            { "name" => "title", "type" => "string" }
+          ],
+          "layout" => [
+            { "invalid" => "format" }
+          ]
+        }
+      }
+
+      it "returns false with errors" do
+        expect(validator.validate).to eq(false)
+        expect(validator.errors.first).to match(/did not match any of the required schemas/)
+      end
+    end
+
+    context "when schema has no layout" do
+      let(:schema) {
+        {
+          "key" => "card",
+          "name" => "Card",
+          "attributes" => [
+            { "name" => "title", "type" => "string" }
+          ]
+        }
+      }
+
+      it "returns true (layout is optional)" do
+        expect(validator.validate).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for validating layout definitions in custom types. Custom types can now optionally include a layout key that defines how their attributes are organised in the site builder form UI.

The validator ensures:
- Layout structure matches the JSON schema (groups with elements)
- All referenced attributes exist in the custom type's attributes array
- No duplicate attribute references in the layout
- `accordion_toggle` elements reference a boolean attribute as `toggle_attribute`
- Layout is optional - custom types without a layout remain valid