### PR TITLE
Add `cache` to menu schema permitted keys

### DIFF
--- a/lib/canvas/validators/menu_schema.rb
+++ b/lib/canvas/validators/menu_schema.rb
@@ -33,7 +33,7 @@ module Canvas
     #   ]
     # }
     class MenuSchema
-      PERMITTED_KEYS = %w[max_item_levels supports_open_new_tab attributes layout].freeze
+      PERMITTED_KEYS = %w[cache max_item_levels supports_open_new_tab attributes layout].freeze
       ADDITIONAL_RESERVED_NAMES = %w[items type].freeze
 
       attr_reader :schema, :errors
@@ -49,6 +49,7 @@ module Canvas
       def validate
         if ensure_valid_format
           ensure_no_unrecognized_keys
+          ensure_cache_is_valid
           ensure_max_item_levels_is_valid
           ensure_layout_is_valid
           ensure_attributes_are_valid
@@ -72,6 +73,17 @@ module Canvas
         return true if unrecognized_keys.empty?
 
         @errors << "Unrecognized keys: #{unrecognized_keys.join(', ')}"
+        false
+      end
+
+      def ensure_cache_is_valid
+        return true unless schema.key?("cache")
+
+        value = schema["cache"]
+        return true if value == true || value == false
+        return true if value.to_s == "true" || value.to_s == "false"
+
+        @errors << "\"cache\" must be true or false"
         false
       end
 

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.21.0"
+  VERSION = "4.22.0"
 end

--- a/spec/lib/canvas/validators/menu_schema_spec.rb
+++ b/spec/lib/canvas/validators/menu_schema_spec.rb
@@ -211,6 +211,67 @@ describe Canvas::Validator::MenuSchema do
         end
       end
 
+      context "when cache is true" do
+        let(:schema) {
+          {
+            "cache" => true
+          }
+        }
+
+        it "returns true" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+
+      context "when cache is false" do
+        let(:schema) {
+          {
+            "cache" => false
+          }
+        }
+
+        it "returns true" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+
+      context "when cache is a string true" do
+        let(:schema) {
+          {
+            "cache" => "true"
+          }
+        }
+
+        it "returns true" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+
+      context "when cache is a string false" do
+        let(:schema) {
+          {
+            "cache" => "false"
+          }
+        }
+
+        it "returns true" do
+          expect(validator.validate).to eq(true)
+        end
+      end
+
+      context "when cache is not a boolean" do
+        let(:schema) {
+          {
+            "cache" => "yes"
+          }
+        }
+
+        it "returns false with errors" do
+          expect(validator.validate).to eq(false)
+          expect(validator.errors).to include("\"cache\" must be true or false")
+        end
+      end
+
       context "when the `layout` is valid" do
         let(:schema) {
           {


### PR DESCRIPTION
## Summary

Adds support for a `cache` key in the menu (header) schema so themes can opt out of system-level header caching via front matter. This enables dynamic content in headers (e.g. cart count) whilst allowing existing headers to keep their current cached behaviour.

## Changes

- **`lib/canvas/validators/menu_schema.rb`**
  - Added `"cache"` to `PERMITTED_KEYS`.
  - Added `ensure_cache_is_valid`: when `cache` is present it must be a boolean (`true`/`false`) or the strings `"true"`/`"false"`. Any other value (e.g. `"yes"`) causes validation to fail with `"cache" must be true or false`.
  - Invoke `ensure_cache_is_valid` from `validate` alongside existing checks.

- **`spec/lib/canvas/validators/menu_schema_spec.rb`**
  - Added examples for: `cache: true`, `cache: false`, `cache: "true"`, `cache: "false"` (all valid), and `cache: "yes"` (invalid, expects error).

## Why

Site headers are cached by default. To support a cart icon with a live item count, headers need to be rendered without the full-template cache. The platform will use `cache: false` in the header front matter to disable that cache for new headers; existing headers without the key remain cached. This gem change allows the key to be present and validated; the main app will sync it to the `cached` column on save.

## Backward compatibility

- Additive only: existing schemas without `cache` continue to validate as before.
- The key is optional; validation only runs when `cache` is present.

## Testing

- `bundle exec rspec spec/lib/canvas/validators/menu_schema_spec.rb`
