### PR TITLE
Fix ReDoS in FrontMatterExtractor#scan

### DIFF
--- a/lib/canvas/services/front_matter_extractor.rb
+++ b/lib/canvas/services/front_matter_extractor.rb
@@ -34,7 +34,9 @@ module Canvas
     # and the HTML content.
     def scan(markup)
       markup = markup.gsub(/\t/, "  ")
-      [*markup.match(/(?:---\s+(.*?)\s+---\s+)(.*\s?)$/m)&.captures]
+      return [] unless markup.strip.start_with?("---")
+
+      [*markup.match(/\A\s*---\s*\n(.*?)\n\s*---\s*\n(.*)\z/m)&.captures]
     end
   end
 end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.22.0"
+  VERSION = "4.22.1"
 end

--- a/spec/lib/canvas/services/front_matter_extractor_spec.rb
+++ b/spec/lib/canvas/services/front_matter_extractor_spec.rb
@@ -58,6 +58,14 @@ describe Canvas::FrontMatterExtractor do
         expect(service.front_matter).to eq(nil)
       end
     end
+
+    context "when markup is large and has no front matter" do
+      let(:markup) { "<div>#{"<p>content</p>\n" * 10_000}</div>" }
+
+      it "returns nil without timeout" do
+        expect(service.front_matter).to eq(nil)
+      end
+    end
   end
 
   describe "#html" do
@@ -97,6 +105,14 @@ describe Canvas::FrontMatterExtractor do
 
       it "returns empty string" do
         expect(service.html).to eq("")
+      end
+    end
+
+    context "when markup is large and has no front matter" do
+      let(:markup) { "<div>#{"<p>content</p>\n" * 10_000}</div>" }
+
+      it "returns the full markup without timeout" do
+        expect(service.html).to eq(markup)
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes catastrophic regex backtracking in `FrontMatterExtractor#scan` that causes `Regexp::TimeoutError` when `Regexp.timeout = 1` is enabled (Rails 8.0 default).

The regex `/(?:---\s+(.*?)\s+---\s+)(.*\s?)$/m` has overlapping quantifiers (`.*?` and `\s+`) in multiline mode. On certain large Liquid markup (e.g. the maverick-race.com footer), this causes exponential backtracking that exceeds the 1-second timeout.

**Two fixes:**
- Short-circuit with `start_with?("---")` before running any regex — non-front-matter content never touches the regex engine
- Anchor the pattern with `\A` and use explicit `\n` delimiters instead of `\s+` to eliminate ambiguous quantifier overlap

## Sentry

- [EASOL-1RA](https://easol.sentry.io/issues/EASOL-1RA) — `ActionView::Template::Error: regexp match timeout` on `Sites::PagesController#index` for `maverick-race.com`

## Test plan

- [x] Existing specs pass
- [x] Added regression specs for large markup without front matter
- [ ] CI passes

Fixes ENG-12959

🤖 Generated with [Claude Code](https://claude.com/claude-code)