### PR TITLE
Compile via sass-embedded API instead of the dartsass CLI

### DIFF
--- a/canvas.gemspec
+++ b/canvas.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency "cli-ui", "~> 1.5"
   s.add_dependency "liquid", "~> 5.3"
   s.add_dependency "dartsass-rails", "~> 0.4"
+  s.add_dependency "sass-embedded", "~> 1.0"
   s.add_dependency "json-schema", "~> 4"
 end

--- a/lib/canvas/dartsass.rb
+++ b/lib/canvas/dartsass.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
-require "open3"
+require "sass-embedded"
 
 module Canvas
-  # This is a thin wrapper around the dartsass binary as provided by
-  # dartsass-rails.
+  # Compiles SCSS with dart-sass via the sass-embedded Ruby API.
   #
   # It is compatible with SassC::Engine as much as we were using it, but 100%
   # compatability is not a goal.
+  #
+  # We use the in-process API rather than shelling out to the `dartsass`
+  # executable: the CLI resolves `Gem.bin_path("sass-embedded", "sass")`, which
+  # is ambiguous (and noisy on stderr) whenever another bundled gem — e.g. the
+  # legacy `sass` gem — also ships a `sass` executable. The API has no such
+  # dependency on executable resolution and avoids a subprocess per render.
   class DartSass
     Error = Class.new(StandardError)
 
@@ -17,31 +22,15 @@ module Canvas
     end
 
     def render
-      stdout, stderr, status = Open3.capture3(*command, stdin_data: @css)
-
-      if status == 0
-        stdout
-      else
-        raise Error.new(stderr)
-      end
-    end
-
-    private
-
-    def command
-      [dartsass, "--stdin", style, *load_paths].compact
-    end
-
-    def dartsass
-      Gem.bin_path("dartsass-rails", "dartsass").shellescape
-    end
-
-    def style
-      (s = @config[:style]) && "--style=#{s.to_s.shellescape}"
-    end
-
-    def load_paths
-      Array(@config[:load_paths]).map { "--load-path=#{_1.shellescape}" }
+      Sass.compile_string(
+        @css,
+        load_paths: Array(@config[:load_paths]),
+        style: @config[:style] || :expanded
+      ).css
+    rescue Sass::CompileError => e
+      # detailed_message keeps the formatted dart-sass error (source snippet and
+      # line:column) the CLI used to print to stderr; highlight: false strips ANSI.
+      raise Error.new(e.detailed_message(highlight: false))
     end
   end
 end

--- a/lib/canvas/version.rb
+++ b/lib/canvas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Canvas
-  VERSION = "4.22.0"
+  VERSION = "4.23.0"
 end

--- a/spec/lib/canvas/dartsass_spec.rb
+++ b/spec/lib/canvas/dartsass_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe Canvas::DartSass do
+  describe "#render" do
+    it "compiles SCSS to CSS" do
+      result = described_class.new("a { b { color: red; } }", {}).render
+
+      expect(result).to include("a b")
+      expect(result).to include("color: red")
+    end
+
+    it "honours the compressed style" do
+      result = described_class.new("a { color: red; }", { style: :compressed }).render
+
+      expect(result).not_to include("\n")
+    end
+
+    it "resolves imports from the configured load paths" do
+      Dir.mkdir("partials")
+      File.write("partials/_vars.scss", "$c: blue;")
+
+      result = described_class.new(
+        %(@import "vars"; a { color: $c; }),
+        { load_paths: ["partials"] }
+      ).render
+
+      expect(result).to include("color: blue")
+    end
+
+    it "wraps a compiler failure in Canvas::DartSass::Error" do
+      expect { described_class.new("a { color: red", {}).render }
+        .to raise_error(Canvas::DartSass::Error)
+    end
+  end
+end


### PR DESCRIPTION
## What & why

`Canvas::DartSass` compiled SCSS by shelling out to the `dartsass` executable, which resolves `Gem.bin_path("sass-embedded", "sass")`. If a consuming app's bundle contains another gem that also ships a `sass` executable — for example the legacy `sass` gem, which older versions of `bootstrap` pull in transitively — Bundler prints an executable-conflict **warning** to the subprocess's stderr. The warning is harmless on its own, but `Canvas::DartSass` raises `Error.new(stderr)` on any non-zero exit, so the warning can surface as a compile error and intermittently break stylesheet compilation at request time.

This switches `Canvas::DartSass#render` to compile through the in-process **sass-embedded Ruby API** (`Sass.compile_string`). Same dart-sass engine, but:
- no subprocess per render (faster, no fork/spawn fragility),
- no dependency on executable resolution, so the `sass` / `sass-embedded` ambiguity can't arise,
- genuine compile failures raise `Sass::CompileError`, which we re-wrap as `Canvas::DartSass::Error`.

The public interface (`Canvas::DartSass.new(css, config).render`, `Canvas::DartSass::Error`, and the `:style` / `:load_paths` config keys) is unchanged, so consumers — including `Validator::Sass` / `ValidSassCheck` — need no changes.

Error output is preserved: `CompileError#detailed_message(highlight: false)` keeps the formatted dart-sass error (source snippet + line:column) that the CLI used to print to stderr, minus ANSI codes.

## Notes
- `sass-embedded` is promoted to an explicit gemspec dependency (it was already present transitively via `dartsass-rails`).
- Version bumped 4.22.0 → 4.23.0.

## Testing
- New `spec/lib/canvas/dartsass_spec.rb` covers compile, compressed style, load-path imports, and the `Sass::CompileError → DartSass::Error` wrapping.
- Full suite green: 295 examples, 0 failures (including `valid_sass_check_spec`, which asserts the error format).